### PR TITLE
security: set fixed PATH in shell scripts

### DIFF
--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -2,6 +2,10 @@
 # Cordelia PreCompact Hook - Flush insights before context compaction (R2-011)
 # Reads transcript_path from stdin, passes to pre-compact.mjs
 
+# Security: Use fixed, unwriteable directories only (prevents PATH injection attacks)
+PATH="/usr/local/bin:/usr/bin:/bin"
+export PATH
+
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Source encryption key

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Cordelia SessionEnd Hook - Update ephemeral memory via MCP
 
+# Security: Use fixed, unwriteable directories only (prevents PATH injection attacks)
+PATH="/usr/local/bin:/usr/bin:/bin"
+export PATH
+
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Source encryption key from seed-drill .mcp.json

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -2,6 +2,10 @@
 # Cordelia SessionStart Hook - Load L1 hot context via MCP
 # stdout from SessionStart hooks is added to context
 
+# Security: Use fixed, unwriteable directories only (prevents PATH injection attacks)
+PATH="/usr/local/bin:/usr/bin:/bin"
+export PATH
+
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Source encryption key from seed-drill .mcp.json

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,10 @@
 
 set -e
 
+# Security: Use fixed, unwriteable directories only (prevents PATH injection attacks)
+PATH="/usr/local/bin:/usr/bin:/bin"
+export PATH
+
 CORDELIA_DIR="$(cd "$(dirname "$0")" && pwd)"
 USER_ID=""
 NO_EMBEDDINGS=false

--- a/scripts/backup-cron-wrapper.sh
+++ b/scripts/backup-cron-wrapper.sh
@@ -19,6 +19,10 @@
 
 set -euo pipefail
 
+# Security: Use fixed, unwriteable directories only (prevents PATH injection attacks)
+PATH="/usr/local/bin:/usr/bin:/bin"
+export PATH
+
 ENV_FILE="$HOME/.cordelia-env"
 
 if [ ! -f "$ENV_FILE" ]; then

--- a/scripts/backup-memory-db.sh
+++ b/scripts/backup-memory-db.sh
@@ -55,6 +55,10 @@
 
 set -euo pipefail
 
+# Security: Use fixed, unwriteable directories only (prevents PATH injection attacks)
+PATH="/usr/local/bin:/usr/bin:/bin"
+export PATH
+
 DB_PATH="/Users/russellwing/cordelia/memory/cordelia.db"
 BACKUP_PATH="/Users/russellwing/cordelia/memory/cordelia-backup.db"
 # Direct hosts (reachable from WireGuard)

--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -5,6 +5,10 @@
 
 set -euo pipefail
 
+# Security: Use fixed, unwriteable directories only (prevents PATH injection attacks)
+PATH="/usr/local/bin:/usr/bin:/bin"
+export PATH
+
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # Patterns that indicate real secrets (not references/docs/env var names)

--- a/setup.sh
+++ b/setup.sh
@@ -15,6 +15,10 @@
 
 set -e
 
+# Security: Use fixed, unwriteable directories only (prevents PATH injection attacks)
+PATH="/usr/local/bin:/usr/bin:/bin"
+export PATH
+
 CORDELIA_DIR="$(cd "$(dirname "$0")" && pwd)"
 USER_ID=""
 ENCRYPTION_KEY=""


### PR DESCRIPTION
Add secure PATH declaration to all shell scripts to prevent PATH injection attacks. Only includes fixed, unwriteable system directories (/usr/local/bin:/usr/bin:/bin).

Addresses SonarCloud security hotspot.

https://claude.ai/code/session_014R9HKda6uidkqp94z1kaKu