### PR TITLE
Add OAuth 2.0 authorization server for MCP authentication

### DIFF
--- a/dashboard/consent.html
+++ b/dashboard/consent.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cordelia - Authorize Application</title>
+  <link rel="stylesheet" href="css/styles.css">
+  <style>
+    .consent-container {
+      min-height: 80vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .consent-card {
+      background: white;
+      border: 1px solid var(--color-border);
+      border-radius: 12px;
+      padding: 3rem;
+      max-width: 480px;
+      width: 100%;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    }
+
+    .consent-header {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+
+    .consent-logo {
+      font-size: 3rem;
+      margin-bottom: 1rem;
+    }
+
+    .consent-title {
+      color: var(--color-deep-green);
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .consent-subtitle {
+      color: var(--color-muted);
+    }
+
+    .client-info {
+      background-color: #f8f9fa;
+      border: 1px solid var(--color-border);
+      border-radius: 8px;
+      padding: 1.25rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .client-name {
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--color-charcoal);
+      margin-bottom: 0.25rem;
+    }
+
+    .client-id {
+      font-size: 0.85rem;
+      color: var(--color-muted);
+      font-family: monospace;
+    }
+
+    .scope-section {
+      margin-bottom: 1.5rem;
+    }
+
+    .scope-section h3 {
+      font-size: 1rem;
+      color: var(--color-charcoal);
+      margin-bottom: 0.75rem;
+    }
+
+    .scope-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    .scope-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.75rem;
+      padding: 0.75rem;
+      background-color: #f8f9fa;
+      border-radius: 6px;
+      margin-bottom: 0.5rem;
+    }
+
+    .scope-icon {
+      font-size: 1.25rem;
+      flex-shrink: 0;
+    }
+
+    .scope-details h4 {
+      font-size: 0.95rem;
+      color: var(--color-charcoal);
+      margin-bottom: 0.25rem;
+    }
+
+    .scope-details p {
+      font-size: 0.85rem;
+      color: var(--color-muted);
+      margin: 0;
+    }
+
+    .user-section {
+      background-color: #e8f5e9;
+      border: 1px solid #c8e6c9;
+      border-radius: 8px;
+      padding: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .user-section p {
+      margin: 0;
+      font-size: 0.9rem;
+      color: #2e7d32;
+    }
+
+    .user-section strong {
+      font-weight: 600;
+    }
+
+    .action-buttons {
+      display: flex;
+      gap: 1rem;
+    }
+
+    .btn {
+      flex: 1;
+      padding: 0.875rem 1.5rem;
+      border-radius: 6px;
+      font-size: 1rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s;
+      text-align: center;
+      border: none;
+    }
+
+    .btn-primary {
+      background-color: var(--color-deep-green);
+      color: white;
+    }
+
+    .btn-primary:hover {
+      background-color: #1a4a3a;
+    }
+
+    .btn-secondary {
+      background-color: white;
+      color: var(--color-charcoal);
+      border: 1px solid var(--color-border);
+    }
+
+    .btn-secondary:hover {
+      background-color: #f5f5f5;
+    }
+
+    .btn:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    .consent-footer {
+      margin-top: 1.5rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--color-border);
+      font-size: 0.85rem;
+      color: var(--color-muted);
+      text-align: center;
+    }
+
+    .error-message {
+      background-color: #fee;
+      border: 1px solid #fcc;
+      color: #c00;
+      padding: 1rem;
+      border-radius: 6px;
+      margin-bottom: 1.5rem;
+    }
+
+    .login-prompt {
+      text-align: center;
+      padding: 2rem;
+    }
+
+    .login-prompt p {
+      margin-bottom: 1rem;
+      color: var(--color-muted);
+    }
+
+    .login-prompt .btn {
+      display: inline-block;
+      text-decoration: none;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Cordelia</h1>
+    <div></div>
+  </header>
+
+  <main class="consent-container">
+    <div class="consent-card">
+      <div class="consent-header">
+        <div class="consent-logo">🔐</div>
+        <h2 class="consent-title">Authorize Application</h2>
+        <p class="consent-subtitle">An application wants to access your Cordelia memory</p>
+      </div>
+
+      <div id="error-message" class="error-message" style="display: none;"></div>
+
+      <!-- Login prompt (shown if not authenticated) -->
+      <div id="login-prompt" class="login-prompt" style="display: none;">
+        <p>You need to sign in to authorize this application.</p>
+        <a href="/login.html" class="btn btn-primary" id="login-link">Sign In</a>
+      </div>
+
+      <!-- Consent form (shown if authenticated) -->
+      <div id="consent-form" style="display: none;">
+        <div class="client-info">
+          <div class="client-name" id="client-name">Unknown Application</div>
+          <div class="client-id" id="client-id"></div>
+        </div>
+
+        <div class="user-section">
+          <p>Signed in as <strong id="user-name"></strong></p>
+        </div>
+
+        <div class="scope-section">
+          <h3>This application will be able to:</h3>
+          <ul class="scope-list" id="scope-list">
+            <!-- Populated by JavaScript -->
+          </ul>
+        </div>
+
+        <div class="action-buttons">
+          <button type="button" class="btn btn-secondary" id="deny-btn">Deny</button>
+          <button type="button" class="btn btn-primary" id="authorize-btn">Authorize</button>
+        </div>
+
+        <div class="consent-footer">
+          <p>By authorizing, you allow this application to access your memory according to the permissions above.</p>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <p>Project Cordelia - Seed Drill</p>
+  </footer>
+
+  <script>
+    const API_BASE = '';
+
+    // Scope descriptions
+    const SCOPE_INFO = {
+      'memory_read': {
+        icon: '📖',
+        title: 'Read your memory',
+        description: 'Access your stored identity, preferences, and context'
+      },
+      'memory_write': {
+        icon: '✏️',
+        title: 'Write to your memory',
+        description: 'Update your stored information and preferences'
+      },
+      'memory_search': {
+        icon: '🔍',
+        title: 'Search your memory',
+        description: 'Search through your entities, sessions, and learnings'
+      },
+      'mcp': {
+        icon: '🧠',
+        title: 'Full MCP access',
+        description: 'Complete access to all Cordelia memory features via MCP'
+      }
+    };
+
+    // Get URL parameters
+    function getParams() {
+      const params = new URLSearchParams(window.location.search);
+      return {
+        clientId: params.get('client_id'),
+        clientName: params.get('client_name'),
+        redirectUri: params.get('redirect_uri'),
+        state: params.get('state'),
+        scope: params.get('scope'),
+        codeChallenge: params.get('code_challenge'),
+        resource: params.get('resource')
+      };
+    }
+
+    // Populate scope list
+    function populateScopes(scopeString) {
+      const scopeList = document.getElementById('scope-list');
+      const scopes = scopeString ? scopeString.split(' ').filter(Boolean) : ['mcp'];
+
+      // If 'mcp' scope is present, just show that (it includes all)
+      if (scopes.includes('mcp')) {
+        const info = SCOPE_INFO['mcp'];
+        scopeList.innerHTML = `
+          <li class="scope-item">
+            <span class="scope-icon">${info.icon}</span>
+            <div class="scope-details">
+              <h4>${info.title}</h4>
+              <p>${info.description}</p>
+            </div>
+          </li>
+        `;
+        return;
+      }
+
+      // Otherwise show individual scopes
+      scopeList.innerHTML = scopes.map(scope => {
+        const info = SCOPE_INFO[scope] || {
+          icon: '🔑',
+          title: scope,
+          description: 'Access permission'
+        };
+        return `
+          <li class="scope-item">
+            <span class="scope-icon">${info.icon}</span>
+            <div class="scope-details">
+              <h4>${info.title}</h4>
+              <p>${info.description}</p>
+            </div>
+          </li>
+        `;
+      }).join('');
+    }
+
+    // Handle authorization decision
+    async function handleDecision(approved) {
+      const params = getParams();
+      const authorizeBtn = document.getElementById('authorize-btn');
+      const denyBtn = document.getElementById('deny-btn');
+
+      authorizeBtn.disabled = true;
+      denyBtn.disabled = true;
+      authorizeBtn.textContent = approved ? 'Authorizing...' : 'Authorize';
+      denyBtn.textContent = approved ? 'Deny' : 'Denying...';
+
+      try {
+        const response = await fetch(`${API_BASE}/oauth/consent`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            approved,
+            client_id: params.clientId,
+            state: params.state,
+            code_challenge: params.codeChallenge,
+            redirect_uri: params.redirectUri,
+            scope: params.scope,
+            resource: params.resource
+          })
+        });
+
+        const data = await response.json();
+
+        if (data.redirect_url) {
+          window.location.href = data.redirect_url;
+        } else if (data.error) {
+          showError(data.error);
+          authorizeBtn.disabled = false;
+          denyBtn.disabled = false;
+          authorizeBtn.textContent = 'Authorize';
+          denyBtn.textContent = 'Deny';
+        }
+      } catch (error) {
+        showError('Connection error. Please try again.');
+        authorizeBtn.disabled = false;
+        denyBtn.disabled = false;
+        authorizeBtn.textContent = 'Authorize';
+        denyBtn.textContent = 'Deny';
+      }
+    }
+
+    // Show error message
+    function showError(message) {
+      const errorEl = document.getElementById('error-message');
+      errorEl.textContent = message;
+      errorEl.style.display = 'block';
+    }
+
+    // Initialize
+    async function init() {
+      const params = getParams();
+
+      if (!params.clientId || !params.redirectUri || !params.codeChallenge) {
+        showError('Invalid authorization request. Missing required parameters.');
+        return;
+      }
+
+      // Check auth status
+      try {
+        const response = await fetch(`${API_BASE}/auth/status`);
+        const data = await response.json();
+
+        if (!data.authenticated) {
+          // Show login prompt, preserve OAuth params
+          document.getElementById('login-prompt').style.display = 'block';
+          const loginLink = document.getElementById('login-link');
+          loginLink.href = `/login.html?redirect=${encodeURIComponent(window.location.pathname + window.location.search)}`;
+          return;
+        }
+
+        // User is authenticated, show consent form
+        document.getElementById('consent-form').style.display = 'block';
+        document.getElementById('client-name').textContent = params.clientName || 'Unknown Application';
+        document.getElementById('client-id').textContent = params.clientId;
+        document.getElementById('user-name').textContent = data.cordelia_user || data.username || 'Unknown';
+
+        populateScopes(params.scope);
+
+        // Set up button handlers
+        document.getElementById('authorize-btn').addEventListener('click', () => handleDecision(true));
+        document.getElementById('deny-btn').addEventListener('click', () => handleDecision(false));
+
+      } catch (error) {
+        showError('Failed to check authentication status.');
+      }
+    }
+
+    init();
+  </script>
+</body>
+</html>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -543,11 +543,16 @@
           <p class="card-description">Manage your API keys for CLI sync, export your data, or delete your profile.</p>
           <div class="account-actions">
             <div class="account-action">
-              <h3>API Key for CLI Sync</h3>
-              <p>Generate an API key to sync your local Cordelia with the cloud.</p>
+              <h3>API Key for MCP &amp; CLI</h3>
+              <p>Generate an API key to authenticate MCP connections and CLI sync.</p>
               <div id="api-key-display" style="display: none; margin-bottom: 1rem;">
                 <code id="api-key-value" style="display: block; background: #1a1a1a; color: #10b981; padding: 0.75rem; border-radius: 6px; font-size: 0.85rem; word-break: break-all; margin-bottom: 0.5rem;"></code>
                 <button class="btn btn-secondary" onclick="copyApiKey()" id="copy-btn">Copy to Clipboard</button>
+                <div id="mcp-config-display" style="margin-top: 1rem;">
+                  <p style="color: #9ca3af; font-size: 0.85rem; margin-bottom: 0.5rem;">Add this to your <code>~/.claude.json</code> mcpServers:</p>
+                  <pre id="mcp-config-value" style="background: #1a1a1a; color: #60a5fa; padding: 0.75rem; border-radius: 6px; font-size: 0.75rem; overflow-x: auto; white-space: pre-wrap; word-break: break-all;"></pre>
+                  <button class="btn btn-secondary" onclick="copyMcpConfig()" id="copy-mcp-btn" style="margin-top: 0.5rem;">Copy MCP Config</button>
+                </div>
               </div>
               <button class="btn btn-primary" onclick="generateApiKey()" id="generate-key-btn">Generate New API Key</button>
             </div>

--- a/dashboard/login.html
+++ b/dashboard/login.html
@@ -269,15 +269,42 @@
   <script>
     const API_BASE = '';
 
+    // Get redirect parameter
+    function getRedirectParam() {
+      const params = new URLSearchParams(window.location.search);
+      return params.get('redirect');
+    }
+
+    // Store redirect intent for after OAuth
+    function storeRedirectIntent() {
+      const redirect = getRedirectParam();
+      if (redirect) {
+        localStorage.setItem('cordelia_login_redirect', redirect);
+      }
+    }
+
+    // Get post-login redirect URL
+    function getPostLoginUrl() {
+      const redirect = localStorage.getItem('cordelia_login_redirect');
+      localStorage.removeItem('cordelia_login_redirect');
+      if (redirect === 'mcp') {
+        return '/mcp-setup.html';
+      }
+      return '/';
+    }
+
     // Check auth status and configure login options
     async function init() {
+      // Store redirect intent before any redirects
+      storeRedirectIntent();
+
       try {
         const response = await fetch(`${API_BASE}/auth/status`);
         const data = await response.json();
 
-        // If already authenticated, redirect to home
+        // If already authenticated, redirect appropriately
         if (data.authenticated) {
-          window.location.href = '/';
+          window.location.href = getPostLoginUrl();
           return;
         }
 
@@ -309,6 +336,18 @@
           noAuthMessage.style.display = 'block';
           skipLink.style.display = 'block';
         }
+
+        // Show MCP context message if redirected from MCP
+        if (getRedirectParam() === 'mcp') {
+          const infoEl = document.querySelector('.login-info');
+          infoEl.innerHTML = `
+            <h4>MCP Authentication Required</h4>
+            <p>
+              Sign in to get your API key for connecting Claude Code to Cordelia.
+              After login, you'll see your MCP configuration to copy.
+            </p>
+          `;
+        }
       } catch (error) {
         console.error('Failed to check auth status:', error);
         document.getElementById('skip-link').style.display = 'block';
@@ -338,7 +377,7 @@
         const data = await response.json();
 
         if (response.ok && data.success) {
-          window.location.href = '/';
+          window.location.href = getPostLoginUrl();
         } else {
           errorEl.textContent = data.error || 'Login failed';
           errorEl.style.display = 'block';

--- a/dashboard/mcp-setup.html
+++ b/dashboard/mcp-setup.html
@@ -1,0 +1,410 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cordelia - MCP Setup</title>
+  <link rel="stylesheet" href="css/styles.css">
+  <style>
+    .setup-container {
+      min-height: 80vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+    }
+
+    .setup-card {
+      background: white;
+      border: 1px solid var(--color-border);
+      border-radius: 12px;
+      padding: 2.5rem;
+      max-width: 600px;
+      width: 100%;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    }
+
+    .setup-title {
+      color: var(--color-deep-green);
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
+
+    .setup-subtitle {
+      color: var(--color-muted);
+      margin-bottom: 2rem;
+      text-align: center;
+    }
+
+    .step {
+      margin-bottom: 2rem;
+      padding-bottom: 1.5rem;
+      border-bottom: 1px solid var(--color-border);
+    }
+
+    .step:last-child {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+
+    .step-header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .step-number {
+      background: var(--color-deep-green);
+      color: white;
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.85rem;
+      font-weight: 600;
+    }
+
+    .step-title {
+      font-size: 1.1rem;
+      color: var(--color-charcoal);
+    }
+
+    .step-content {
+      margin-left: 40px;
+    }
+
+    .code-block {
+      background: #1a1a1a;
+      color: #10b981;
+      padding: 1rem;
+      border-radius: 6px;
+      font-family: monospace;
+      font-size: 0.85rem;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-all;
+      margin-bottom: 0.75rem;
+    }
+
+    .code-block.json {
+      color: #60a5fa;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.625rem 1.25rem;
+      border-radius: 6px;
+      font-size: 0.9rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background-color 0.2s;
+      border: none;
+    }
+
+    .btn-primary {
+      background-color: var(--color-deep-green);
+      color: white;
+    }
+
+    .btn-primary:hover {
+      background-color: #1a4a3a;
+    }
+
+    .btn-primary:disabled {
+      background-color: #999;
+      cursor: not-allowed;
+    }
+
+    .btn-secondary {
+      background-color: #e5e5e5;
+      color: var(--color-charcoal);
+    }
+
+    .btn-secondary:hover {
+      background-color: #d5d5d5;
+    }
+
+    .button-row {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .success-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: #d1fae5;
+      color: #065f46;
+      padding: 0.5rem 1rem;
+      border-radius: 6px;
+      font-size: 0.9rem;
+    }
+
+    .loading {
+      text-align: center;
+      padding: 2rem;
+      color: var(--color-muted);
+    }
+
+    .error-message {
+      background-color: #fee;
+      border: 1px solid #fcc;
+      color: #c00;
+      padding: 1rem;
+      border-radius: 6px;
+      margin-bottom: 1.5rem;
+    }
+
+    .footer-links {
+      margin-top: 2rem;
+      text-align: center;
+    }
+
+    .footer-links a {
+      color: var(--color-deep-green);
+      text-decoration: none;
+    }
+
+    .footer-links a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Cordelia</h1>
+    <div id="header-actions"></div>
+  </header>
+
+  <main class="setup-container">
+    <div class="setup-card">
+      <h2 class="setup-title">MCP Setup for Claude Code</h2>
+      <p class="setup-subtitle">Connect Claude Code to your Cordelia memory</p>
+
+      <div id="loading" class="loading">Loading...</div>
+      <div id="error" class="error-message" style="display: none;"></div>
+
+      <div id="setup-steps" style="display: none;">
+        <div class="step">
+          <div class="step-header">
+            <span class="step-number">1</span>
+            <span class="step-title">Generate API Key</span>
+          </div>
+          <div class="step-content">
+            <div id="api-key-status"></div>
+          </div>
+        </div>
+
+        <div class="step">
+          <div class="step-header">
+            <span class="step-number">2</span>
+            <span class="step-title">Copy MCP Configuration</span>
+          </div>
+          <div class="step-content">
+            <p style="color: var(--color-muted); margin-bottom: 0.75rem; font-size: 0.9rem;">
+              Add this to your <code>~/.claude.json</code> file under <code>mcpServers</code>:
+            </p>
+            <pre id="mcp-config" class="code-block json"></pre>
+            <div class="button-row">
+              <button class="btn btn-secondary" onclick="copyConfig()" id="copy-btn">Copy Configuration</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="step">
+          <div class="step-header">
+            <span class="step-number">3</span>
+            <span class="step-title">Restart Claude Code</span>
+          </div>
+          <div class="step-content">
+            <p style="color: var(--color-muted); font-size: 0.9rem;">
+              After updating your config, restart Claude Code to connect to Cordelia.
+              You can verify the connection with <code>/mcp list</code>.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="footer-links">
+        <a href="/">Go to Dashboard</a>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    <p>Project Cordelia - Seed Drill</p>
+  </footer>
+
+  <script>
+    const API_BASE = '';
+    let currentUserId = null;
+    let currentApiKey = null;
+
+    async function checkAuth() {
+      const response = await fetch(`${API_BASE}/auth/status`);
+      return await response.json();
+    }
+
+    async function generateApiKey(userId) {
+      const response = await fetch(`${API_BASE}/api/profile/${encodeURIComponent(userId)}/api-key`, {
+        method: 'POST',
+      });
+      return await response.json();
+    }
+
+    async function loadUserContext(userId) {
+      const response = await fetch(`${API_BASE}/api/hot/${encodeURIComponent(userId)}`);
+      if (!response.ok) return null;
+      return await response.json();
+    }
+
+    function showMcpConfig(apiKey) {
+      const config = {
+        cordelia: {
+          url: `${window.location.origin}/mcp/sse`,
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+        },
+      };
+      document.getElementById('mcp-config').textContent = JSON.stringify(config, null, 2);
+    }
+
+    function copyConfig() {
+      const config = document.getElementById('mcp-config').textContent;
+      navigator.clipboard.writeText(config).then(() => {
+        const btn = document.getElementById('copy-btn');
+        btn.textContent = 'Copied!';
+        setTimeout(() => {
+          btn.textContent = 'Copy Configuration';
+        }, 2000);
+      }).catch(err => {
+        console.error('Failed to copy:', err);
+        alert('Failed to copy to clipboard');
+      });
+    }
+
+    async function init() {
+      const loadingEl = document.getElementById('loading');
+      const errorEl = document.getElementById('error');
+      const stepsEl = document.getElementById('setup-steps');
+      const apiKeyStatusEl = document.getElementById('api-key-status');
+
+      try {
+        // Check auth
+        const auth = await checkAuth();
+        if (!auth.authenticated) {
+          window.location.href = '/login.html?redirect=mcp';
+          return;
+        }
+
+        currentUserId = auth.cordelia_user;
+
+        if (!currentUserId) {
+          // User doesn't have a Cordelia profile yet
+          window.location.href = '/genesis.html';
+          return;
+        }
+
+        // Check if user already has an API key
+        const context = await loadUserContext(currentUserId);
+        currentApiKey = context?.identity?.api_key;
+
+        loadingEl.style.display = 'none';
+        stepsEl.style.display = 'block';
+
+        if (currentApiKey) {
+          // Already has an API key
+          apiKeyStatusEl.innerHTML = `
+            <div class="success-badge">API Key Ready</div>
+            <p style="color: var(--color-muted); margin-top: 0.75rem; font-size: 0.9rem;">
+              Your API key is already configured.
+            </p>
+            <div class="button-row" style="margin-top: 0.75rem;">
+              <button class="btn btn-secondary" onclick="regenerateKey()">Regenerate Key</button>
+            </div>
+          `;
+          showMcpConfig(currentApiKey);
+        } else {
+          // Need to generate an API key
+          apiKeyStatusEl.innerHTML = `
+            <p style="color: var(--color-muted); margin-bottom: 0.75rem; font-size: 0.9rem;">
+              You need an API key to authenticate MCP connections.
+            </p>
+            <button class="btn btn-primary" onclick="generateKey()" id="generate-btn">Generate API Key</button>
+          `;
+          document.getElementById('mcp-config').textContent = '// Generate an API key first';
+        }
+
+      } catch (error) {
+        console.error('Init error:', error);
+        loadingEl.style.display = 'none';
+        errorEl.textContent = 'Failed to load: ' + error.message;
+        errorEl.style.display = 'block';
+      }
+    }
+
+    async function generateKey() {
+      const btn = document.getElementById('generate-btn');
+      btn.disabled = true;
+      btn.textContent = 'Generating...';
+
+      try {
+        const result = await generateApiKey(currentUserId);
+        if (result.success && result.api_key) {
+          currentApiKey = result.api_key;
+          document.getElementById('api-key-status').innerHTML = `
+            <div class="success-badge">API Key Generated</div>
+            <p style="color: var(--color-muted); margin-top: 0.75rem; font-size: 0.9rem;">
+              Your API key has been created and saved.
+            </p>
+            <div class="button-row" style="margin-top: 0.75rem;">
+              <button class="btn btn-secondary" onclick="regenerateKey()">Regenerate Key</button>
+            </div>
+          `;
+          showMcpConfig(currentApiKey);
+        } else {
+          alert('Failed to generate API key: ' + (result.error || 'Unknown error'));
+          btn.disabled = false;
+          btn.textContent = 'Generate API Key';
+        }
+      } catch (error) {
+        alert('Failed to generate API key: ' + error.message);
+        btn.disabled = false;
+        btn.textContent = 'Generate API Key';
+      }
+    }
+
+    async function regenerateKey() {
+      if (!confirm('This will invalidate your current API key. Continue?')) {
+        return;
+      }
+
+      try {
+        const result = await generateApiKey(currentUserId);
+        if (result.success && result.api_key) {
+          currentApiKey = result.api_key;
+          showMcpConfig(currentApiKey);
+          alert('API key regenerated. Update your Claude Code config with the new key.');
+        } else {
+          alert('Failed to regenerate API key: ' + (result.error || 'Unknown error'));
+        }
+      } catch (error) {
+        alert('Failed to regenerate API key: ' + error.message);
+      }
+    }
+
+    // Clear any redirect intent
+    localStorage.removeItem('cordelia_login_redirect');
+
+    init();
+  </script>
+</body>
+</html>

--- a/src/oauth-clients-store.ts
+++ b/src/oauth-clients-store.ts
@@ -1,0 +1,175 @@
+/**
+ * Project Cordelia - OAuth Registered Clients Store
+ *
+ * Implements OAuthRegisteredClientsStore interface from MCP SDK.
+ * Stores OAuth clients in SQLite with hashed secrets.
+ */
+
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { SqliteStorageProvider, OAuthClientRow } from './storage-sqlite.js';
+import {
+  generateClientId,
+  generateClientSecret,
+  hashToken,
+  calculateExpiry,
+  DEFAULT_CLIENT_SECRET_EXPIRY,
+} from './oauth-tokens.js';
+
+export interface CordeliaOAuthClientsStoreOptions {
+  storage: SqliteStorageProvider;
+  clientSecretExpirySeconds?: number;
+}
+
+/**
+ * Cordelia OAuth Clients Store backed by SQLite.
+ */
+export class CordeliaOAuthClientsStore implements OAuthRegisteredClientsStore {
+  private storage: SqliteStorageProvider;
+  private clientSecretExpirySeconds: number;
+
+  constructor(options: CordeliaOAuthClientsStoreOptions) {
+    this.storage = options.storage;
+    this.clientSecretExpirySeconds = options.clientSecretExpirySeconds ?? DEFAULT_CLIENT_SECRET_EXPIRY;
+  }
+
+  /**
+   * Get a registered OAuth client by ID.
+   * Returns the client info without the secret (secret is hashed in DB).
+   */
+  async getClient(clientId: string): Promise<OAuthClientInformationFull | undefined> {
+    const row = await this.storage.getOAuthClient(clientId);
+    if (!row) {
+      return undefined;
+    }
+    return this.rowToClientInfo(row);
+  }
+
+  /**
+   * Register a new OAuth client.
+   * Generates client_id and client_secret, stores hashed secret.
+   * Returns full client info including the plaintext secret (only time it's available).
+   */
+  async registerClient(
+    client: Omit<OAuthClientInformationFull, 'client_id' | 'client_id_issued_at'>
+  ): Promise<OAuthClientInformationFull> {
+    const clientId = generateClientId();
+    const clientSecret = generateClientSecret();
+    const clientSecretHash = hashToken(clientSecret);
+    const clientIdIssuedAt = Math.floor(Date.now() / 1000);
+
+    // Calculate secret expiry (null for public clients)
+    let clientSecretExpiresAt: number | null = null;
+    if (client.token_endpoint_auth_method !== 'none') {
+      clientSecretExpiresAt = calculateExpiry(this.clientSecretExpirySeconds);
+    }
+
+    // Build the row for storage
+    const row: Omit<OAuthClientRow, 'created_at' | 'updated_at'> = {
+      client_id: clientId,
+      client_secret_hash: clientSecretHash,
+      client_id_issued_at: clientIdIssuedAt,
+      client_secret_expires_at: clientSecretExpiresAt,
+      redirect_uris: JSON.stringify(client.redirect_uris.map(u => u.toString())),
+      token_endpoint_auth_method: client.token_endpoint_auth_method ?? 'client_secret_post',
+      grant_types: JSON.stringify(client.grant_types ?? ['authorization_code', 'refresh_token']),
+      response_types: JSON.stringify(client.response_types ?? ['code']),
+      client_name: client.client_name ?? null,
+      client_uri: client.client_uri?.toString() ?? null,
+      logo_uri: client.logo_uri?.toString() ?? null,
+      scope: client.scope ?? null,
+      contacts: client.contacts ? JSON.stringify(client.contacts) : null,
+      software_id: client.software_id ?? null,
+      software_version: client.software_version ?? null,
+      owner_user_id: null, // Will be set by caller if needed
+    };
+
+    await this.storage.createOAuthClient(row);
+
+    // Return full client info with plaintext secret
+    return {
+      client_id: clientId,
+      client_secret: clientSecret, // Only time the plaintext is returned
+      client_id_issued_at: clientIdIssuedAt,
+      client_secret_expires_at: clientSecretExpiresAt ?? undefined,
+      redirect_uris: client.redirect_uris,
+      token_endpoint_auth_method: client.token_endpoint_auth_method,
+      grant_types: client.grant_types,
+      response_types: client.response_types,
+      client_name: client.client_name,
+      client_uri: client.client_uri,
+      logo_uri: client.logo_uri,
+      scope: client.scope,
+      contacts: client.contacts,
+      software_id: client.software_id,
+      software_version: client.software_version,
+    };
+  }
+
+  /**
+   * Verify a client secret against the stored hash.
+   * @param clientId The client ID
+   * @param clientSecret The plaintext secret to verify
+   * @returns true if secret matches
+   */
+  async verifyClientSecret(clientId: string, clientSecret: string): Promise<boolean> {
+    const row = await this.storage.getOAuthClient(clientId);
+    if (!row || !row.client_secret_hash) {
+      return false;
+    }
+
+    const providedHash = hashToken(clientSecret);
+    return providedHash === row.client_secret_hash;
+  }
+
+  /**
+   * Convert a database row to OAuthClientInformationFull.
+   * Note: client_secret is not included (it's only stored as a hash).
+   */
+  private rowToClientInfo(row: OAuthClientRow): OAuthClientInformationFull {
+    // Note: logo_uri and client_uri are stored as strings but SDK expects URL objects
+    const result: OAuthClientInformationFull = {
+      client_id: row.client_id,
+      // client_secret is intentionally omitted (only hash is stored)
+      client_id_issued_at: row.client_id_issued_at,
+      client_secret_expires_at: row.client_secret_expires_at ?? undefined,
+      redirect_uris: JSON.parse(row.redirect_uris).map((u: string) => new URL(u)),
+      token_endpoint_auth_method: row.token_endpoint_auth_method,
+      grant_types: JSON.parse(row.grant_types),
+      response_types: JSON.parse(row.response_types),
+      client_name: row.client_name ?? undefined,
+      scope: row.scope ?? undefined,
+      contacts: row.contacts ? JSON.parse(row.contacts) : undefined,
+      software_id: row.software_id ?? undefined,
+      software_version: row.software_version ?? undefined,
+    };
+
+    // Add optional URL fields if present
+    if (row.client_uri) {
+      (result as Record<string, unknown>).client_uri = new URL(row.client_uri);
+    }
+    if (row.logo_uri) {
+      (result as Record<string, unknown>).logo_uri = new URL(row.logo_uri);
+    }
+
+    return result;
+  }
+
+  /**
+   * Delete a client (for cleanup/revocation).
+   */
+  async deleteClient(clientId: string): Promise<boolean> {
+    return this.storage.deleteOAuthClient(clientId);
+  }
+
+  /**
+   * Check if a client secret has expired.
+   */
+  isClientSecretExpired(client: OAuthClientInformationFull): boolean {
+    if (!client.client_secret_expires_at) {
+      return false; // No expiry = never expires
+    }
+    const now = Math.floor(Date.now() / 1000);
+    return now >= client.client_secret_expires_at;
+  }
+}

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1,0 +1,422 @@
+/**
+ * Project Cordelia - OAuth Server Provider
+ *
+ * Implements OAuthServerProvider interface from MCP SDK.
+ * Handles the complete OAuth 2.0 authorization flow.
+ */
+
+import type { Response } from 'express';
+import type { OAuthServerProvider, AuthorizationParams, OAuthTokenVerifier } from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import type { OAuthClientInformationFull, OAuthTokens, OAuthTokenRevocationRequest } from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { SqliteStorageProvider } from './storage-sqlite.js';
+import { CordeliaOAuthClientsStore } from './oauth-clients-store.js';
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  generateAuthorizationCode,
+  hashToken,
+  verifyPKCE,
+  isExpired,
+  calculateExpiry,
+  parseScopes,
+  joinScopes,
+  DEFAULT_ACCESS_TOKEN_EXPIRY,
+  DEFAULT_REFRESH_TOKEN_EXPIRY,
+  DEFAULT_AUTHORIZATION_CODE_EXPIRY,
+  SUPPORTED_SCOPES,
+} from './oauth-tokens.js';
+
+export interface CordeliaOAuthProviderOptions {
+  storage: SqliteStorageProvider;
+  baseUrl: string;
+  accessTokenExpirySeconds?: number;
+  refreshTokenExpirySeconds?: number;
+  authorizationCodeExpirySeconds?: number;
+}
+
+// Pending authorization requests stored in memory
+interface PendingAuthorization {
+  clientId: string;
+  params: AuthorizationParams;
+  createdAt: number;
+}
+
+/**
+ * Cordelia OAuth Server Provider.
+ * Implements the full OAuth 2.0 authorization code flow with PKCE.
+ */
+export class CordeliaOAuthProvider implements OAuthServerProvider, OAuthTokenVerifier {
+  private storage: SqliteStorageProvider;
+  private _clientsStore: CordeliaOAuthClientsStore;
+  private baseUrl: string;
+  private accessTokenExpirySeconds: number;
+  private refreshTokenExpirySeconds: number;
+  private authorizationCodeExpirySeconds: number;
+
+  // Store pending authorizations keyed by state
+  private pendingAuthorizations = new Map<string, PendingAuthorization>();
+
+  constructor(options: CordeliaOAuthProviderOptions) {
+    this.storage = options.storage;
+    this._clientsStore = new CordeliaOAuthClientsStore({ storage: options.storage });
+    this.baseUrl = options.baseUrl;
+    this.accessTokenExpirySeconds = options.accessTokenExpirySeconds ?? DEFAULT_ACCESS_TOKEN_EXPIRY;
+    this.refreshTokenExpirySeconds = options.refreshTokenExpirySeconds ?? DEFAULT_REFRESH_TOKEN_EXPIRY;
+    this.authorizationCodeExpirySeconds = options.authorizationCodeExpirySeconds ?? DEFAULT_AUTHORIZATION_CODE_EXPIRY;
+  }
+
+  get clientsStore(): OAuthRegisteredClientsStore {
+    return this._clientsStore;
+  }
+
+  /**
+   * Begin the authorization flow.
+   * Redirects to a consent page where the user can approve or deny.
+   */
+  async authorize(
+    client: OAuthClientInformationFull,
+    params: AuthorizationParams,
+    res: Response
+  ): Promise<void> {
+    // Generate a state if not provided
+    const state = params.state || generateAuthorizationCode().slice(0, 16);
+
+    // Store the pending authorization
+    this.pendingAuthorizations.set(state, {
+      clientId: client.client_id,
+      params,
+      createdAt: Date.now(),
+    });
+
+    // Clean up old pending authorizations (older than 10 minutes)
+    this.cleanupPendingAuthorizations();
+
+    // Build the consent page URL
+    const consentUrl = new URL('/oauth/consent', this.baseUrl);
+    consentUrl.searchParams.set('client_id', client.client_id);
+    consentUrl.searchParams.set('client_name', client.client_name || client.client_id);
+    consentUrl.searchParams.set('redirect_uri', params.redirectUri);
+    consentUrl.searchParams.set('state', state);
+    consentUrl.searchParams.set('scope', params.scopes?.join(' ') || '');
+    consentUrl.searchParams.set('code_challenge', params.codeChallenge);
+    if (params.resource) {
+      consentUrl.searchParams.set('resource', params.resource.toString());
+    }
+
+    // Redirect to consent page
+    res.redirect(consentUrl.toString());
+  }
+
+  /**
+   * Complete the authorization after user consent.
+   * Called by the consent endpoint after the user approves.
+   * @returns The authorization code to redirect with
+   */
+  async completeAuthorization(
+    state: string,
+    userId: string,
+    approved: boolean
+  ): Promise<{ code?: string; error?: string; redirectUri: string; state?: string }> {
+    const pending = this.pendingAuthorizations.get(state);
+    if (!pending) {
+      return { error: 'invalid_request', redirectUri: '', state };
+    }
+
+    this.pendingAuthorizations.delete(state);
+
+    const redirectUri = pending.params.redirectUri;
+
+    if (!approved) {
+      return { error: 'access_denied', redirectUri, state: pending.params.state };
+    }
+
+    // Generate authorization code
+    const code = generateAuthorizationCode();
+    const codeHash = hashToken(code);
+
+    // Store the authorization code
+    await this.storage.storeAuthorizationCode(codeHash, {
+      client_id: pending.clientId,
+      user_id: userId,
+      redirect_uri: redirectUri,
+      scope: pending.params.scopes?.join(' ') || null,
+      code_challenge: pending.params.codeChallenge,
+      code_challenge_method: 'S256',
+      expires_at: calculateExpiry(this.authorizationCodeExpirySeconds),
+      resource: pending.params.resource?.toString() || null,
+    });
+
+    return { code, redirectUri, state: pending.params.state };
+  }
+
+  /**
+   * Get the code challenge for an authorization code.
+   */
+  async challengeForAuthorizationCode(
+    _client: OAuthClientInformationFull,
+    authorizationCode: string
+  ): Promise<string> {
+    const codeHash = hashToken(authorizationCode);
+    const codeData = await this.storage.getAuthorizationCode(codeHash);
+
+    if (!codeData) {
+      return '';
+    }
+
+    return codeData.code_challenge;
+  }
+
+  /**
+   * Exchange an authorization code for tokens.
+   */
+  async exchangeAuthorizationCode(
+    client: OAuthClientInformationFull,
+    authorizationCode: string,
+    codeVerifier?: string,
+    redirectUri?: string,
+    resource?: URL
+  ): Promise<OAuthTokens> {
+    const codeHash = hashToken(authorizationCode);
+    const codeData = await this.storage.getAuthorizationCode(codeHash);
+
+    if (!codeData) {
+      throw new Error('Invalid authorization code');
+    }
+
+    // Verify the code hasn't expired
+    if (isExpired(codeData.expires_at)) {
+      await this.storage.deleteAuthorizationCode(codeHash);
+      throw new Error('Authorization code expired');
+    }
+
+    // Verify client ID matches
+    if (codeData.client_id !== client.client_id) {
+      throw new Error('Client ID mismatch');
+    }
+
+    // Verify redirect URI matches
+    if (redirectUri && codeData.redirect_uri !== redirectUri) {
+      throw new Error('Redirect URI mismatch');
+    }
+
+    // Verify PKCE code verifier
+    if (codeVerifier) {
+      if (!verifyPKCE(codeVerifier, codeData.code_challenge, codeData.code_challenge_method)) {
+        throw new Error('Invalid code verifier');
+      }
+    }
+
+    // Consume the authorization code (delete it)
+    await this.storage.deleteAuthorizationCode(codeHash);
+
+    // Generate tokens
+    const accessToken = generateAccessToken();
+    const refreshToken = generateRefreshToken();
+    const accessTokenExpiresAt = calculateExpiry(this.accessTokenExpirySeconds);
+    const refreshTokenExpiresAt = calculateExpiry(this.refreshTokenExpirySeconds);
+
+    // Store access token
+    await this.storage.storeAccessToken(hashToken(accessToken), {
+      client_id: client.client_id,
+      user_id: codeData.user_id,
+      scope: codeData.scope,
+      expires_at: accessTokenExpiresAt,
+      resource: resource?.toString() || codeData.resource,
+    });
+
+    // Store refresh token
+    await this.storage.storeRefreshToken(hashToken(refreshToken), {
+      client_id: client.client_id,
+      user_id: codeData.user_id,
+      scope: codeData.scope,
+      expires_at: refreshTokenExpiresAt,
+      resource: resource?.toString() || codeData.resource,
+      revoked_at: null,
+    });
+
+    return {
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: this.accessTokenExpirySeconds,
+      scope: codeData.scope || undefined,
+      refresh_token: refreshToken,
+    };
+  }
+
+  /**
+   * Exchange a refresh token for a new access token.
+   */
+  async exchangeRefreshToken(
+    client: OAuthClientInformationFull,
+    refreshToken: string,
+    scopes?: string[],
+    resource?: URL
+  ): Promise<OAuthTokens> {
+    const tokenHash = hashToken(refreshToken);
+    const tokenData = await this.storage.getRefreshToken(tokenHash);
+
+    if (!tokenData) {
+      throw new Error('Invalid refresh token');
+    }
+
+    // Check if revoked
+    if (tokenData.revoked_at) {
+      throw new Error('Refresh token has been revoked');
+    }
+
+    // Check if expired
+    if (tokenData.expires_at && isExpired(tokenData.expires_at)) {
+      throw new Error('Refresh token expired');
+    }
+
+    // Verify client ID matches
+    if (tokenData.client_id !== client.client_id) {
+      throw new Error('Client ID mismatch');
+    }
+
+    // Validate requested scopes (must be subset of original)
+    let finalScope = tokenData.scope;
+    if (scopes && scopes.length > 0) {
+      const originalScopes = parseScopes(tokenData.scope);
+      const requestedScopes = new Set(scopes);
+      const originalSet = new Set(originalScopes);
+
+      // All requested scopes must be in original
+      for (const s of requestedScopes) {
+        if (!originalSet.has(s)) {
+          throw new Error(`Scope '${s}' was not in original grant`);
+        }
+      }
+
+      finalScope = joinScopes(scopes);
+    }
+
+    // Generate new access token
+    const accessToken = generateAccessToken();
+    const accessTokenExpiresAt = calculateExpiry(this.accessTokenExpirySeconds);
+
+    // Store new access token
+    await this.storage.storeAccessToken(hashToken(accessToken), {
+      client_id: client.client_id,
+      user_id: tokenData.user_id,
+      scope: finalScope,
+      expires_at: accessTokenExpiresAt,
+      resource: resource?.toString() || tokenData.resource,
+    });
+
+    return {
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: this.accessTokenExpirySeconds,
+      scope: finalScope || undefined,
+      // Don't issue new refresh token by default (can be configured)
+    };
+  }
+
+  /**
+   * Verify an access token and return auth info.
+   */
+  async verifyAccessToken(token: string): Promise<AuthInfo> {
+    const tokenHash = hashToken(token);
+    const tokenData = await this.storage.getAccessToken(tokenHash);
+
+    if (!tokenData) {
+      throw new Error('Invalid access token');
+    }
+
+    // Check expiration
+    if (isExpired(tokenData.expires_at)) {
+      // Clean up expired token
+      await this.storage.deleteAccessToken(tokenHash);
+      throw new Error('Access token expired');
+    }
+
+    return {
+      token,
+      clientId: tokenData.client_id,
+      scopes: parseScopes(tokenData.scope),
+      expiresAt: tokenData.expires_at,
+      resource: tokenData.resource ? new URL(tokenData.resource) : undefined,
+      extra: {
+        userId: tokenData.user_id,
+      },
+    };
+  }
+
+  /**
+   * Revoke an access or refresh token.
+   */
+  async revokeToken(
+    client: OAuthClientInformationFull,
+    request: OAuthTokenRevocationRequest
+  ): Promise<void> {
+    const tokenHash = hashToken(request.token);
+
+    // Try to revoke as access token
+    const accessToken = await this.storage.getAccessToken(tokenHash);
+    if (accessToken) {
+      // Verify client owns this token
+      if (accessToken.client_id === client.client_id) {
+        await this.storage.deleteAccessToken(tokenHash);
+      }
+      return;
+    }
+
+    // Try to revoke as refresh token
+    const refreshToken = await this.storage.getRefreshToken(tokenHash);
+    if (refreshToken) {
+      // Verify client owns this token
+      if (refreshToken.client_id === client.client_id) {
+        await this.storage.revokeRefreshToken(tokenHash);
+      }
+      return;
+    }
+
+    // Token not found - per RFC 7009, this is not an error
+  }
+
+  /**
+   * Get supported scopes for metadata.
+   */
+  getSupportedScopes(): string[] {
+    return SUPPORTED_SCOPES;
+  }
+
+  /**
+   * Clean up expired authorization codes and tokens.
+   */
+  async cleanup(): Promise<{ codes: number; accessTokens: number }> {
+    const codes = await this.storage.cleanupExpiredAuthorizationCodes();
+    const accessTokens = await this.storage.cleanupExpiredAccessTokens();
+    return { codes, accessTokens };
+  }
+
+  /**
+   * Clean up old pending authorizations.
+   */
+  private cleanupPendingAuthorizations(): void {
+    const tenMinutesAgo = Date.now() - 10 * 60 * 1000;
+    for (const [state, pending] of this.pendingAuthorizations) {
+      if (pending.createdAt < tenMinutesAgo) {
+        this.pendingAuthorizations.delete(state);
+      }
+    }
+  }
+
+  /**
+   * Check if a user ID is valid (exists in L1).
+   */
+  async isValidUser(userId: string): Promise<boolean> {
+    const data = await this.storage.readL1(userId);
+    return data !== null;
+  }
+
+  /**
+   * Revoke all tokens for a user.
+   */
+  async revokeAllUserTokens(userId: string): Promise<{ accessTokens: number; refreshTokens: number }> {
+    return this.storage.revokeAllUserTokens(userId);
+  }
+}

--- a/src/oauth-tokens.ts
+++ b/src/oauth-tokens.ts
@@ -1,0 +1,188 @@
+/**
+ * Project Cordelia - OAuth Token Utilities
+ *
+ * Token generation, hashing, and verification for OAuth 2.0 flows.
+ */
+
+import * as crypto from 'crypto';
+
+// Token expiry defaults (in seconds)
+export const DEFAULT_ACCESS_TOKEN_EXPIRY = 3600; // 1 hour
+export const DEFAULT_REFRESH_TOKEN_EXPIRY = 30 * 24 * 3600; // 30 days
+export const DEFAULT_AUTHORIZATION_CODE_EXPIRY = 600; // 10 minutes
+export const DEFAULT_CLIENT_SECRET_EXPIRY = 30 * 24 * 3600; // 30 days
+
+/**
+ * Generate a cryptographically secure random token.
+ * @param bytes Number of random bytes (default: 32)
+ * @returns Base64url-encoded token
+ */
+export function generateToken(bytes = 32): string {
+  return crypto.randomBytes(bytes).toString('base64url');
+}
+
+/**
+ * Generate an access token.
+ * Format: at_<random>
+ */
+export function generateAccessToken(): string {
+  return `at_${generateToken(32)}`;
+}
+
+/**
+ * Generate a refresh token.
+ * Format: rt_<random>
+ */
+export function generateRefreshToken(): string {
+  return `rt_${generateToken(48)}`;
+}
+
+/**
+ * Generate an authorization code.
+ * Format: ac_<random>
+ */
+export function generateAuthorizationCode(): string {
+  return `ac_${generateToken(32)}`;
+}
+
+/**
+ * Generate a client ID.
+ * Uses UUID v4 format.
+ */
+export function generateClientId(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * Generate a client secret.
+ * Format: cs_<random>
+ */
+export function generateClientSecret(): string {
+  return `cs_${generateToken(32)}`;
+}
+
+/**
+ * Hash a token for storage.
+ * Uses SHA-256 to create a fixed-length hash.
+ * @param token The raw token
+ * @returns Hex-encoded SHA-256 hash
+ */
+export function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * Verify a PKCE code verifier against a code challenge.
+ * Only S256 method is supported.
+ * @param verifier The code_verifier from the client
+ * @param challenge The code_challenge stored during authorization
+ * @param method The challenge method (must be 'S256')
+ * @returns true if verification passes
+ */
+export function verifyPKCE(verifier: string, challenge: string, method = 'S256'): boolean {
+  if (method !== 'S256') {
+    throw new Error('Only S256 PKCE method is supported');
+  }
+
+  // S256: BASE64URL(SHA256(code_verifier))
+  const computed = crypto
+    .createHash('sha256')
+    .update(verifier)
+    .digest('base64url');
+
+  return computed === challenge;
+}
+
+/**
+ * Generate a PKCE code verifier and challenge pair (for testing).
+ * @returns Object with verifier and challenge
+ */
+export function generatePKCE(): { verifier: string; challenge: string } {
+  // Code verifier: 43-128 characters from unreserved URI characters
+  const verifier = generateToken(32);
+
+  // Code challenge: BASE64URL(SHA256(verifier))
+  const challenge = crypto
+    .createHash('sha256')
+    .update(verifier)
+    .digest('base64url');
+
+  return { verifier, challenge };
+}
+
+/**
+ * Check if a token has expired.
+ * @param expiresAt Expiration timestamp (epoch seconds)
+ * @returns true if expired
+ */
+export function isExpired(expiresAt: number | null): boolean {
+  if (expiresAt === null) {
+    return false; // null means never expires
+  }
+  const now = Math.floor(Date.now() / 1000);
+  return now >= expiresAt;
+}
+
+/**
+ * Calculate expiration timestamp.
+ * @param expirySeconds Seconds until expiration
+ * @returns Epoch timestamp (seconds)
+ */
+export function calculateExpiry(expirySeconds: number): number {
+  return Math.floor(Date.now() / 1000) + expirySeconds;
+}
+
+/**
+ * Parse scope string into array.
+ * @param scope Space-separated scope string
+ * @returns Array of scopes
+ */
+export function parseScopes(scope: string | null | undefined): string[] {
+  if (!scope) return [];
+  return scope.split(/\s+/).filter(Boolean);
+}
+
+/**
+ * Join scopes array into string.
+ * @param scopes Array of scopes
+ * @returns Space-separated scope string
+ */
+export function joinScopes(scopes: string[]): string {
+  return scopes.join(' ');
+}
+
+/**
+ * Check if requested scopes are a subset of allowed scopes.
+ * @param requested Requested scopes
+ * @param allowed Allowed scopes
+ * @returns true if all requested scopes are allowed
+ */
+export function validateScopes(requested: string[], allowed: string[]): boolean {
+  const allowedSet = new Set(allowed);
+  return requested.every(scope => allowedSet.has(scope));
+}
+
+/**
+ * Cordelia-specific scopes.
+ */
+export const CORDELIA_SCOPES = {
+  MEMORY_READ: 'memory_read',
+  MEMORY_WRITE: 'memory_write',
+  MEMORY_SEARCH: 'memory_search',
+  MCP: 'mcp', // Full MCP access
+} as const;
+
+/**
+ * Default scopes for MCP clients.
+ */
+export const DEFAULT_MCP_SCOPES = [
+  CORDELIA_SCOPES.MEMORY_READ,
+  CORDELIA_SCOPES.MEMORY_WRITE,
+  CORDELIA_SCOPES.MEMORY_SEARCH,
+  CORDELIA_SCOPES.MCP,
+];
+
+/**
+ * All supported scopes.
+ */
+export const SUPPORTED_SCOPES = Object.values(CORDELIA_SCOPES);


### PR DESCRIPTION
## Summary

- Implements OAuth 2.0 authorization code flow with PKCE for MCP client authentication
- Adds dynamic client registration for MCP clients
- Provides consent UI for users to approve OAuth applications
- Maintains backward compatibility with legacy API keys during migration

## Changes

### New Files
- `src/oauth-provider.ts` - OAuthServerProvider implementation (MCP SDK interface)
- `src/oauth-tokens.ts` - Token generation, PKCE verification, scope handling
- `src/oauth-clients-store.ts` - Dynamic client registration storage
- `dashboard/consent.html` - OAuth consent page
- `dashboard/mcp-setup.html` - MCP client setup instructions

### Modified Files
- `src/storage-sqlite.ts` - OAuth tables (clients, tokens, authorization codes)
- `src/http-server.ts` - OAuth consent endpoints and MCP auth router integration
- `dashboard/` - Minor UI updates for OAuth flow

## Test plan

- [ ] Register a new OAuth client via dynamic registration
- [ ] Complete authorization flow with PKCE
- [ ] Verify token issuance and refresh
- [ ] Test consent page approval/denial
- [ ] Verify legacy API key auth still works (deprecated path)
- [ ] Test token revocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)